### PR TITLE
add banner to guild update changes

### DIFF
--- a/src/bot/events/guildUpdate.js
+++ b/src/bot/events/guildUpdate.js
@@ -132,6 +132,13 @@ module.exports = {
             name: 'Splash Image ⚠ WARNING: This isn\'t changed very often',
             value: `► Now: **${after}**\n► Was: **${before}**`
           }
+        case 'banner':
+          before = oldGuild.banner ? `[This](${oldGuild.bannerURL})` : 'None'
+          after = newGuild.banner ? `[This](${newGuild.bannerURL})` : 'None'
+          return {
+            name: 'Banner',
+            value: `► Now: **${after}**\n► Was: **${before}**`
+          }
       }
     }
   }


### PR DESCRIPTION
This PR adds a new property to `guildUpdate` logs that was added recently to guilds the `Banner` prop. 

![image](https://user-images.githubusercontent.com/23035000/72582757-d741c500-38b1-11ea-84dc-09c05a6925a2.png)


**NOTE:** This is an untested PR. I do not have a Tier 2 boosted server where I can test this at this time. According to Eris typings, this **SHOULD** work but again it is untested. It would be nice to get this tested if possible.