### PR TITLE
Update setchannel.js

### DIFF
--- a/src/bot/commands/setchannel.js
+++ b/src/bot/commands/setchannel.js
@@ -16,7 +16,6 @@ const eventList = [
   'guildUpdate',
   'messageDelete',
   'messageDeleteBulk',
-  'messageReactionRemoveAll',
   'messageUpdate',
   'guildMemberAdd',
   'guildMemberKick',
@@ -36,6 +35,7 @@ module.exports = {
     if (!webhookPerm) {
       message.channel.createMessage('I lack the manage webhooks permission! This is necessary for me to send messages to your configured logging channel.').catch(_ => {})
       message.addReaction('❌').catch(_ => {})
+      return
     }
     let events = suffix.split(', ')
     events = cleanArray(events)


### PR DESCRIPTION
Fix a bug, where the bot continues to set the channel for the logging event(s) when it's missing permissions. 
Also remove `messageReactionRemoveAll` event from valid events array