### PR TITLE
[help.js]: Yell at them if the bot can't send a DM

### DIFF
--- a/src/bot/commands/help.js
+++ b/src/bot/commands/help.js
@@ -4,7 +4,8 @@ module.exports = {
     try {
       DMC = await message.author.getDMChannel()
     } catch (e) {
-      return message.channel.createMessage(`<@${message.author.id}>, you're not capable of receiving a DM from me.`).catch(() => {})
+      message.channel.createMessage(`<@${message.author.id}>, you're not capable of receiving a DM from me.`).catch(() => {})
+      return
     }
 
     if (suffix) {
@@ -81,6 +82,8 @@ module.exports = {
       } catch (_) {
         console.log(_)
         message.addReaction('❌')
+        message.channel.createMessage(`<@${message.author.id}>, you're not capable of receiving a DM from me.`).catch(() => {})
+        return
       }
     }
   },


### PR DESCRIPTION
For some reason it's not showing the message when creating the dm... so include it in the catch aswell. 