### PR TITLE
add sticker update logging

### DIFF
--- a/src/bot/commands/setchannel.js
+++ b/src/bot/commands/setchannel.js
@@ -26,6 +26,7 @@ const eventList = [
   'guildMemberNickUpdate',
   'guildMemberVerify',
   'guildEmojisUpdate',
+  'guildStickersUpdate',
   'guildMemberBoostUpdate'
 ]
 

--- a/src/bot/events/guildStickersUpdate.js
+++ b/src/bot/events/guildStickersUpdate.js
@@ -1,0 +1,87 @@
+const send = require('../modules/webhooksender')
+const AUDIT_ID = {
+  added: 90,
+  removed: 92,
+  updated: 91
+}
+
+const STICKER_FORMAT_TYPES = {
+  1: 'PNG',
+  2: 'APNG',
+  3: 'LOTTIE',
+}
+
+module.exports = {
+  name: 'guildStickersUpdate',
+  type: 'on',
+  handle: async (guild, stickers, oldStickers) => {
+    console.log("STICKER UPDATED")
+    let type
+    const guildStickersUpdateEvent = {
+      guildID: guild.id,
+      eventName: 'guildStickersUpdate',
+      embeds: [{
+        description: 'Guild stickers were updated.',
+        fields: [{
+          name: 'Sticker was manipulated',
+          value: ''
+        }, {
+          name: 'ID',
+          value: '```ini\nUser = Unknown\nSticker = Unknown```'
+        }],
+        color: 3553599
+      }]
+    }
+    let sticker
+    if (stickers.length > oldStickers.length) {
+      const newStickers = stickers.filter(e => !oldStickers.find(o => o.id === e.id))
+      sticker = newStickers[0]
+      if (!sticker) {
+        return
+      }
+      type = 'added'
+      guildStickersUpdateEvent.embeds[0].thumbnail = {
+        url: `https://cdn.discordapp.com/stickers/${sticker.id}.png?v=1`
+      }
+      guildStickersUpdateEvent.embeds[0].fields[0].name = 'Added sticker'
+      guildStickersUpdateEvent.embeds[0].fields[0].value = `Name = ${sticker.name}\nDescription = ${sticker.description}\nFormat = ${STICKER_FORMAT_TYPES[sticker.format_type]}`
+    } else if (oldStickers.length > stickers.length) {
+      const removedStickers = oldStickers.filter(e => !stickers.find(o => o.id === e.id))
+      sticker = removedStickers[0]
+      type = 'removed'
+      guildStickersUpdateEvent.embeds[0].fields[0].name = 'Removed sticker'
+      guildStickersUpdateEvent.embeds[0].fields[0].value = `Name = ${sticker.name}\nDescription = ${sticker.description}\nFormat = ${STICKER_FORMAT_TYPES[sticker.format_type]}`
+    } else {
+      type = 'updated'
+      sticker = stickers.find(e => oldStickers.find(o => o.id === e.id).name !== e.name)
+      if (!sticker) return
+      guildStickersUpdateEvent.embeds[0].fields[0].name = 'Updated sticker'
+      guildStickersUpdateEvent.embeds[0].fields[0].value = `Name = ${sticker.name}\nDescription = ${sticker.description}\nFormat = ${STICKER_FORMAT_TYPES[sticker.format_type]}`
+      guildStickersUpdateEvent.embeds[0].thumbnail = {
+        url: `https://cdn.discordapp.com/stickers/${sticker.id}.png?v=1`
+      }
+      const oldSticker = oldStickers.find(o => o.id === sticker.id)
+      if (sticker.name !== oldSticker.name) {
+        guildStickersUpdateEvent.embeds[0].fields[0].value += `\nName was = ${oldSticker.name}`
+      }
+      if (sticker.description !== oldSticker.description) {
+        guildStickersUpdateEvent.embeds[0].fields[0].value += `\nDescription was = ${oldSticker.description}`
+      }
+    }
+    await setTimeout(async () => {
+      const num = AUDIT_ID[type]
+      const logs = await guild.getAuditLog({ limit: 5, actionType: num }).catch((err) => {console.log(err)})
+      if (!logs) return
+      const log = logs.entries.find(e => e?.targetID === sticker.id && Date.now() - ((e.id / 4194304) + 1420070400000) < 3000)
+      if (log && log.user) { // if the audit log is less than 3 seconds off
+        const user = log.user
+        guildStickersUpdateEvent.embeds[0].author = {
+          name: `${user.username}#${user.discriminator}`,
+          icon_url: user.avatarURL
+        }
+        guildStickersUpdateEvent.embeds[0].fields[1].value = `\`\`\`ini\nUser = ${user.id}\nSticker = ${sticker.id}\`\`\``
+      }
+      await send(guildStickersUpdateEvent)
+    }, 1000)
+  }
+}

--- a/src/bot/modules/eventmiddleware.js
+++ b/src/bot/modules/eventmiddleware.js
@@ -55,6 +55,7 @@ function getGuildIdByEvent (type, args) {
     case 'guildBanAdd':
     case 'guildBanRemove':
     case 'guildEmojisUpdate':
+    case 'guildStickersUpdate':
     case 'guildMemberAdd':
     case 'guildMemberUpdate':
     case 'guildRoleCreate':

--- a/src/bot/modules/statAggregator.js
+++ b/src/bot/modules/statAggregator.js
@@ -29,6 +29,7 @@ const eventStatistics = {
   guildCreate: 0,
   guildDelete: 0,
   guildEmojisUpdate: 0,
+  guildStickersUpdate: 0,
   guildMemberAdd: 0,
   guildMemberKick: 0,
   guildMemberRemove: 0,

--- a/src/bot/utils/constants.js
+++ b/src/bot/utils/constants.js
@@ -22,6 +22,7 @@ exports.ALL_EVENTS = [
   'voiceStateUpdate',
   'voiceChannelSwitch',
   'guildEmojisUpdate',
+  'guildStickersUpdate',
   'guildMemberBoostUpdate'
 ]
 
@@ -67,7 +68,8 @@ exports.EVENTS_USING_AUDITLOGS = [
   'guildMemberRemove',
   'guildMemberUpdate',
   'voiceStateUpdate',
-  'guildEmojisUpdate'
+  'guildEmojisUpdate',
+  'guildStickersUpdate'
 ]
 
 exports.EMBED_COLORS = {

--- a/src/db/interfaces/postgres/create.js
+++ b/src/db/interfaces/postgres/create.js
@@ -27,6 +27,7 @@ const eventLogs = {
   voiceStateUpdate: '',
   voiceChannelSwitch: '',
   guildEmojisUpdate: '',
+  guildStickersUpdate: '',
   guildMemberNickUpdate: '',
   guildMemberBoostUpdate: ''
 }

--- a/src/db/interfaces/postgres/update.js
+++ b/src/db/interfaces/postgres/update.js
@@ -29,6 +29,7 @@ const eventList = [
   'voiceStateUpdate',
   'voiceChannelSwitch',
   'guildEmojisUpdate',
+  'guildStickersUpdate',
   'guildMemberNickUpdate'
 ]
 
@@ -54,6 +55,7 @@ const eventLogs = {
   voiceStateUpdate: '',
   voiceChannelSwitch: '',
   guildEmojisUpdate: '',
+  guildStickersUpdate: '',
   guildMemberNickUpdate: '',
   guildMemberBoostUpdate: '',
   guildMemberVerify: '' // I am a moron for having an object representing


### PR DESCRIPTION
This is just the code that I used for sticker log changes. Adapted heavily from the emote one.

I had to update to eris 0.16.1 for this since the eris branch you maintain doesn't have the guildStickerUpdate event.

You can close this if you want, but wanted to share in case it helps you. I only run it on 1 server so not sure if you'll hit scaling issues or some other weird issue with the custom eris version.

Pic shows the 3 main events, addition, removal, updates. I couldn't get the animated stickers to play in the embed, not sure why (when you access the url, it's animated). My guess is that it's a Discord bug that PNG's won't animate by default. 
<img width="579" alt="Screen Shot 2022-04-28 at 8 55 08 PM" src="https://user-images.githubusercontent.com/1670606/166077435-3ad0bd7f-fe61-4098-adf8-ffb3cfaea4a0.png">
