### PR TITLE
Tiny fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ BEZERK_URI=ws://localhost:1234
 BEZERK_SECRET=https://github.com/thesharks/bezerk
 RAVEN_URI=sentry uri from sentry.io
 STAT_SUBMISSION_INTERVAL=
+# If you want text commands to be enabled
+ENABLE_TEXT_COMMANDS="true"

--- a/src/bot/modules/commandhandler.js
+++ b/src/bot/modules/commandhandler.js
@@ -29,7 +29,7 @@ function processCommand (message, commandName, suffix) {
   } else if (command.type === 'creator' && !process.env.CREATOR_IDS.includes(message.author.id)) {
     message.channel.createMessage('This command is creator only!')
     return
-  } else if (command.type === 'admin' && !(message.member.permissions.has('administrator' || message.author.id === message.channel.guild.ownerID))) {
+  } else if (command.type === 'admin' && !(message.member.permissions.has('administrator') || message.author.id === message.channel.guild.ownerID)) {
     message.channel.createMessage('That\'s an admin only command. You need the administrator permission to use it.')
     return
   } else if (command.perm && !(message.member.permissions.has(command.perm) || message.author.id === message.channel.guild.ownerID)) {

--- a/src/bot/slashcommands/serverinfo.js
+++ b/src/bot/slashcommands/serverinfo.js
@@ -51,7 +51,7 @@ module.exports = {
         name: 'Emojis',
         value: 'None'
       })
-      interaction.createMessage({ embed }).catch(() => {})
+      interaction.createMessage({ embeds: [embed] }).catch(() => {})
     } else {
       const emojiObj = {
         0: []


### PR DESCRIPTION
- Fixes `commandhandler` perm check for 'admin'
- Updates `/serverinfo` to `({ embeds: [embed] })` instead of `({ embed })`
- Adds `ENABLE_TEXT_COMMANDS` to `.env.example` file. 

> Unsure which version of the `logbots` message you want to go with. (one says all bot activity the other only mentions message edits/deletes)