### PR TITLE
Include perpetrator in message deletion and fix broken optional bot logging

### DIFF
--- a/src/bot/events/messageCreate.js
+++ b/src/bot/events/messageCreate.js
@@ -6,7 +6,7 @@ module.exports = {
   name: 'messageCreate',
   type: 'on',
   handle: async message => {
-    if (message.type === 23 || message.type === 24 || message.author.bot || !message.member) return // do not log automod actions
+    if (message.type === 23 || message.type === 24 || message.author.system || !message.member) return // do not log automod actions
     await commandHandler(message)
     if (message.author.id === global.bot.user.id) return // dump logs made by the bot
     const guildSettings = global.bot.guildSettingsCache[message.channel.guild.id]

--- a/src/bot/events/messageDelete.js
+++ b/src/bot/events/messageDelete.js
@@ -57,13 +57,30 @@ module.exports = {
         value: chunk
       })
     })
-    messageDeleteEvent.embeds[0].fields.push({
-      name: 'Date',
-      value: `<t:${Math.round(cachedMessage.ts / 1000)}:F>`
-    }, {
-      name: 'ID',
-      value: `\`\`\`ini\nUser = ${cachedMessage.author_id}\nMessage = ${cachedMessage.id}\`\`\``
-    })
+    const logs = await message.channel.guild.getAuditLog({ limit: 5, actionType: 72 })
+    const log = logs.entries.find(e => toString(e.id) == toString(message.id))
+    if (log && log.user) {
+      messageDeleteEvent.embeds[0].fields.push({
+        name: 'Date',
+        value: `<t:${Math.round(cachedMessage.ts / 1000)}:F>`
+      }, {
+        name: 'ID',
+        value: `\`\`\`ini\nUser = ${cachedMessage.author_id}\nMessage = ${cachedMessage.id}\nPerpetrator = ${log.user.id}\`\`\``
+      })
+      messageDeleteEvent.embeds[0].footer = {
+        text: `${log.user.username}#${log.user.discriminator}`,
+        icon_url: log.user.avatarURL
+      }
+      console.log("Test: ${log.user.username}")
+    } else {
+      messageDeleteEvent.embeds[0].fields.push({
+        name: 'Date',
+        value: `<t:${Math.round(cachedMessage.ts / 1000)}:F>`
+      }, {
+        name: 'ID',
+        value: `\`\`\`ini\nUser = ${cachedMessage.author_id}\nMessage = ${cachedMessage.id}\nPerpetrator = Unknown\`\`\``
+      })
+    }
     await send(messageDeleteEvent)
   }
 }


### PR DESCRIPTION
Fixed a small issue in the `messageCreate` event handler checking for bot instead of system, this broke the 'logbots' option.
Also made it that `messageDelete` includes the perpetrator in the footer when possible.